### PR TITLE
Be a little less picky about where got_revision comes from.

### DIFF
--- a/bors.py
+++ b/bors.py
@@ -133,7 +133,7 @@ class BuildBot:
             if "properties" not in b:
                 continue
             for props in b["properties"]:
-                if props[0] == "got_revision":
+                if props[0] == "got_revision" and props[2] in ("Source", "Git", "SetProperty Step"):
                     rev = props[1].encode("utf8")
             if rev != None:
                 yield (rev, b)


### PR DESCRIPTION
It turns out that this was the source of my missing-test-results problems earlier. On the Servo Buildbot, I've implemented the builds using external build scripts, so got_revision ends up being set by a SetProperty step rather than Source or Git. I couldn't find any reason why Bors needs to be so picky about, so I removed it.
