### PR TITLE
Version bump.

### DIFF
--- a/bors.py
+++ b/bors.py
@@ -88,7 +88,7 @@ import logging, logging.handlers
 import github
 from time import strftime, gmtime
 
-__version__ = '1.1'
+__version__ = '1.2'
 
 TIMEOUT=60
 


### PR DESCRIPTION
The Servo folks need a Bors upgrade done; bumping the version number makes this much easier to roll out.
