### PR TITLE
allow hyphens in usernames

### DIFF
--- a/bors.py
+++ b/bors.py
@@ -325,7 +325,7 @@ class PullReq:
                 # check for the r=<user> syntax on the commit comment
                 [ m.group(1)
                   for (_,_,c) in self.head_comments
-                  for m in [re.match(r"^r=(\w+)", c)] if m ]
+                  for m in [re.match(r"^r=([a-zA-Z0-9_-]+)", c)] if m ]
                 +
                 # check for the approval tokens followed by the branch SHA in the PR comments from reviewers
                 [ u
@@ -335,7 +335,7 @@ class PullReq:
                 # check for the r=<name> followed by the branch SHA in the PR comments from reviewers
                 [ m.group(1)
                   for (_,_,c) in self.head_comments
-                  for m in [re.match(r"^r=(\w+) ([a-z0-9]+)", c)] if m and u in self.reviewers and self.sha.startswith(m.group(2)) ])
+                  for m in [re.match(r"^r=([a-zA-Z0-9_-]+) ([a-z0-9]+)", c)] if m and u in self.reviewers and self.sha.startswith(m.group(2)) ])
 
     def priority(self):
         p = 0


### PR DESCRIPTION
Previously, GitHub usernames containing hyphens were broken: if a
hyphenated username were provided in a `r=some-body` request to bors,
bors would interpret that request as `r=some`.

The reason for this is the regex parsing the username in those comments
was only looking for a word (`\w+`, or equivalently `[a-zA-Z0-9_]+`),
and words end at hyphens.

This changes those regular expressions to look for any of the word
characters and additionally a hyphen character (`[a-zA-Z0-9_-]+`).

I am not able to test this in production (I don't have the configuration)
but my experiments at the interpreter suggest this regex is correct for
parsing usernames with hyphens.

```
>>> import re
>>> c = 'r=chris-morgan'
>>> [m.group(1)
     for m in [re.match(r"r=([a-zA-Z0-9_-]+)", c)]
     if m]
['chris-morgan']
>>> s = 'r=chris-morgan b2f6b40'
>>> [m.group(1)
     for m in [re.match(r"r=([a-zA-Z0-9_-]+) ([a-z0-9]+)", s)]
     if m]
['chris-morgan']
```

But if anyone has a good clue how to check if this works, let me know.

Closes #38.
